### PR TITLE
feito uma ordenação pela coluna updatedAt na rota de pedidos

### DIFF
--- a/routes/pedidos.js
+++ b/routes/pedidos.js
@@ -14,6 +14,7 @@ router.get("/pedidos", async (req, res, next) => {
         { model: Cliente, as: 'cliente', attributes: ['nome'] },
         { model: Produto, as: 'produto', attributes: ['nome'] },
       ],
+      order: [['updatedAt', 'DESC']],
     });
     res.status(200).json(response);
   } catch (err) {


### PR DESCRIPTION
alteração realizada para melhorar a experiência na página que lista os pedidos, assim a consulta já é enviada ordenada pela data updateAt. Escolhi esta coluna para que ao fazer uma alteração em um pedido este fique no topo como último pedido trabalhado/realizado.
link da PR no front-end: https://github.com/cristianoans/soulpet-front/pull/57